### PR TITLE
Fix for the image dimension calculation with the MinImageSizePositioner

### DIFF
--- a/src/SpriteGenerator/Positioner/MinImageSizePositioner.php
+++ b/src/SpriteGenerator/Positioner/MinImageSizePositioner.php
@@ -24,7 +24,7 @@ class MinImageSizePositioner implements SpritePositionerInterface
         $imgInfo = array();
         $len = count($sourceImages);
         $wc = ceil(sqrt($len));
-        $hc = floor(sqrt($len / 2));
+        $hc = ceil(sqrt($len));
         $maxW = array();
         $maxH = array();
 

--- a/src/SpriteGenerator/Resources/views/plainCss.html.twig
+++ b/src/SpriteGenerator/Resources/views/plainCss.html.twig
@@ -7,6 +7,6 @@
 .{{ key }} {
     width: {{ image.width }}px;
     height: {{ image.height }}px;
-    background-position: -{{ image.pos_x }}px -{{ image.pos_y }}px;
+    background-position: -{{ image.pos_x }}px -{{ image.pos_y }}px !important; 
 }
 {% endfor %}


### PR DESCRIPTION
I encountered an issue where my generated spritesheet was missing several icons.The CSS was fine.

Example: 15 sprites with 16x16 pixels each. Within the `calculate` function of the `MinImageSizePositioner`, `$wc` would be 4 (which is correct) and `$wh` would be 2. 

This patch fixes the issue.
